### PR TITLE
Transition to Manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,42 +1,34 @@
 {
-    "manifest_version": 2,
-    "name": "ProToots",
-    "version": "0.99",
+	"manifest_version": 2,
+	"name": "ProToots",
+	"version": "0.99",
 
+	"description": "puts pronouns next to usernames on mastodon",
+	"homepage_url": "https://github.com/ItsVipra/ProToots",
+	"permissions": ["storage"],
 
-    "description": "puts pronouns next to usernames on mastodon",
-    "homepage_url": "https://github.com/ItsVipra/ProToots",
-    "permissions": [
-        "storage"
-    ],
+	"browser_action": {
+		"default_icon": "src/icons/beasts-32.png",
+		"default_title": "ProToots",
+		"default_popup": "src/options/options.html"
+	},
 
-    "browser_action": {
-        "default_icon": "src/icons/beasts-32.png",
-        "default_title": "ProToots",
-        "default_popup": "src/options/options.html"
-    },
+	"content_scripts": [
+		{
+			"matches": ["*://*/*"],
+			"js": ["src/content_scripts/protoots.js"],
+			"css": ["src/styles/proplate.css"],
+			"run_at": "document_start"
+		}
+	],
 
-    "content_scripts": [
-        {
-            "matches": [
-                "*://*/*"
-            ],
-            "js" : [
-                "src/content_scripts/protoots.js"
-            ],
-            "css": ["src/styles/proplate.css"],
-            "run_at": "document_start"
-        }
-    ],
+	"options_ui": {
+		"page": "src/options/options.html"
+	},
 
-    "options_ui": {
-        "page": "src/options/options.html"
-    },
-
-    "browser_specific_settings": {
-        "gecko": {
-            "id": "protoots@mastodon.com"
-        }
-    }
-
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "protoots@mastodon.com"
+		}
+	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,17 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "ProToots",
 	"version": "0.99",
 
 	"description": "puts pronouns next to usernames on mastodon",
 	"homepage_url": "https://github.com/ItsVipra/ProToots",
 	"permissions": ["storage"],
-
-	"browser_action": {
+	"action": {
 		"default_icon": "src/icons/beasts-32.png",
 		"default_title": "ProToots",
 		"default_popup": "src/options/options.html"
 	},
-
+	"optional_host_permissions": ["*://*/*"],
 	"content_scripts": [
 		{
 			"matches": ["*://*/*"],


### PR DESCRIPTION
## TODO

- [ ] Plates are not added on click
- [ ] The permission is revoked after navigating to a different tab inside the Mastodon interface
- [ ] Settings are not persisted
- [ ] There should be an info message on how to persist the permission for the current page.
  - [ ] Even better, that should be done by clicking a button on the popup.

Closes #14.