### PR TITLE
Fix logging arguments

### DIFF
--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -11,24 +11,29 @@ const host_name = location.hostname;
 checkSite();
 let logging;
 
-function error() {
-	if (logging) console.error(arguments);
+/** @param {any[]} arguments */
+function error(...arguments) {
+	if (logging) console.error(...arguments);
 }
 
-function warn() {
-	if (logging) console.warn(arguments);
+/** @param {any[]} arguments */
+function warn(...arguments) {
+	if (logging) console.warn(...arguments);
 }
 
-function log() {
-	if (logging) console.log(arguments);
+/** @param {any[]} arguments */
+function log(...arguments) {
+	if (logging) console.log(...arguments);
 }
 
-function info() {
-	if (logging) console.info(arguments);
+/** @param {any[]} arguments */
+function info(...arguments) {
+	if (logging) console.info(...arguments);
 }
 
-function debug() {
-	if (logging) console.debug(arguments);
+/** @param {any[]} arguments */
+function debug(...arguments) {
+	if (logging) console.debug(...arguments);
 }
 
 // log("hey vippy, du bist cute <3")

--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -43,14 +43,14 @@ function debug(...arguments) {
  * If so creates an 'readystatechange' EventListener, with callback to main()
  */
 async function checkSite() {
-	await browser.storage.sync.get("logging").then(
-		(res) => {
-			logging = res["logging"];
-		},
-		() => {
-			logging = true;
-		},
-	);
+	try {
+		let { logging: optionValue } = await browser.storage.sync.get("logging");
+		logging = optionValue;
+	} catch {
+		//  Enable the logging automatically if we cannot determine the user preference.
+		logging = true;
+	}
+
 	let requestDest = location.protocol + "//" + host_name + "/api/v1/instance";
 	let response = await fetch(requestDest);
 


### PR DESCRIPTION
The arguments are passed as variadic ones, resulting in the expected beautiful logs. yay. :3

And because I was already working on it, I rewrote the fetching of the option with `try/catch`. 

