### PR TITLE
Refactor the usage of the observer

### DIFF
--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -95,7 +95,7 @@ function main() {
 		// We might have existing statuses in this mutation, therefore we are also searching for those.
 		// For some weird reason, this does not work with the findStatusesAndAddProplates method
 		// below, only with the querySelector.
-		document.querySelectorAll(".status, .detailed-status").forEach(s => addProplate(s));
+		document.querySelectorAll(".status, .detailed-status").forEach((s) => addProplate(s));
 	}).observe(document, { subtree: true, childList: true });
 }
 

--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -3,6 +3,9 @@
 //proplate.textContent = "pro/nouns";
 //document.body.display-name__html.append();
 
+// obligatory crime. because be gay, do crime.
+// 8======D
+
 // const max_age = 8.64e7
 const max_age = 24 * 60 * 60 * 1000; //time after which cached pronouns should be checked again: 24h
 const host_name = location.host;

--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -83,7 +83,7 @@ function main() {
 
 		// Checks whether the given n is a column in the Mastodon interface. This is true for the simple
 		// as well as the advanced interface.
-		const isColumn = (n) => n instanceof HTMLElement && containsClass(n.classList, "column");
+		const isColumn = (n) => n instanceof HTMLElement && hasClasses(n.classList, "column");
 
 		// Observe and wait for added columns. We are using flatMap on all addedNodes, because columns
 		// multiple nodes might be added in one single mutation. By flattening the tree, we can be sure
@@ -107,7 +107,7 @@ function main() {
 function findStatusesAndAddProplates(mutations) {
 	// Checks whether the given n is a status in the Mastodon interface.
 	const isStatus = (n) =>
-		n instanceof HTMLElement && containsClass(n.classList, ["status", "detailed-status"]);
+		n instanceof HTMLElement && hasClasses(n.classList, "status", "detailed-status");
 
 	mutations.flatMap((m) => [...m.addedNodes].filter(isStatus)).forEach((s) => addProplate(s));
 }
@@ -365,27 +365,17 @@ async function addProplate(element) {
 
 /**
  * @param {DOMTokenList} classList The class list.
- * @param {string|string[]} cl The class(es) to check for.
+ * @param {string[]} cl The class(es) to check for.
  * @returns Whether the classList contains the class.
  */
-function containsClass(classList, cl) {
+function hasClasses(classList, ...cl) {
 	if (!classList || !cl) return false;
 
-	if (Array.isArray(cl)) {
-		for (const c of classList) {
-			for (const c2 of cl) {
-				if (c === c2) return true;
-			}
-		}
-		return false;
-	}
-
 	for (const c of classList) {
-		if (c === cl) {
-			return true;
+		for (const c2 of cl) {
+			if (c === c2) return true;
 		}
 	}
-
 	return false;
 }
 


### PR DESCRIPTION
Instead of having multiple observers, the number got reduced to two. One is listening on the document itself, the other one is watching the columns.

If a column is added or removed, the document observer is tracking the new column. The shared column observer in comparison is waiting for new posts to arrive.