### PR TITLE
Remove all inline styles

### DIFF
--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -204,7 +204,6 @@ async function addProplate(element) {
 			//i think you can figure out what this does on your own
 			proplate.classList.add("proplate-pog");
 		}
-		proplate.style.fontWeight = "500";
 		//add plate to nametag
 		insertAfter(proplate, nametagEl);
 	}
@@ -298,9 +297,7 @@ async function addProplate(element) {
 		const accountName = getAccountName(accountNameEl);
 
 		const nametagEl = getNametagEl(element, ".display-name__html");
-
-		nametagEl.parentElement.style.display = "flex";
-
+		nametagEl.parentElement.classList.add("has-proplate");
 		element.setAttribute("protoots-checked", "true");
 		// Add the checked attribute only _after_ we've passed the basic checks.
 		// This allows us to pass incomplete nodes into this method, because
@@ -326,7 +323,7 @@ async function addProplate(element) {
 		const nametagEl = element.querySelector(".display-name__html");
 		const accountName = getAccountName(element.querySelector(".display-name__account"));
 
-		nametagEl.parentElement.style.display = "flex";
+		nametagEl.parentElement.classList.add("has-proplate");
 
 		element.setAttribute("protoots-checked", "true");
 		generateProPlate(statusId, accountName, nametagEl, "account");

--- a/src/styles/proplate.css
+++ b/src/styles/proplate.css
@@ -6,6 +6,7 @@
 	display: inline-flex;
 	text-transform: lowercase;
 	animation: proplate-fadein 0.15s linear;
+	font-weight: 500;
 }
 
 /* dark theme */
@@ -89,4 +90,8 @@
 	.protoots-proplate {
 		animation: none;
 	}
+}
+
+bdi.has-proplate {
+	display: flex;
 }


### PR DESCRIPTION
Inline styles have the highest specificity and can't be overridden with CSS.
Because it might break other styles (like [Tangerine](https://github.com/nileane/TangerineUI-for-Mastodon/)),
I've replaced the inline CSS completely.
