### PR TITLE
Add GitHub Action for automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ jobs:
     steps:
       - name: Download assets for release
         run: >
-          gh release download ${{ github.ref }} --archive zip --dir assets
+          gh release download ${{ github.ref }} --archive zip --dir assets --output source.zip
           gh release download ${{ github.ref }} --pattern "*firefox*" --dir assets
       - uses: browser-actions/release-firefox-addon@v0.1.3
         with:
           addon-id: "protoots"
           addon-path: "assets/protoots-firefox.zip"
-          source-path: "assets/ProToots-${{ github.ref }}.zip"
+          source-path: "assets/source.zip"
           approval-note: |
             The source code requires Node.js 18 or newer. To generate the source code, run:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,15 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+
+      - name: Update package version
+        run: npm version from-git --no-git-tag-version
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        name: Commit package version update
+        with:
+          commit_message: "Update to ${{ github.ref }}"
+          file_pattern: "package*.json"
+
       - name: Install dependencies
         run: npm ci
       - name: Build packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: npm ci
+      - name: Build packages
+        run: npm run package
+
+      # Create automatic draft release for pushes of tags, prefilled with all the important information.
+      # And since we have our files, let's attach them as well.
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: "web-ext-artifacts/*.zip"
+
+  release-firefox:
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - name: Download assets for release
+        run: >
+          gh release download ${{ github.ref }} --archive zip --dir assets
+          gh release download ${{ github.ref }} --pattern "*firefox*" --dir assets
+      - uses: browser-actions/release-firefox-addon@v0.1.3
+        with:
+          addon-id: "protoots"
+          addon-path: "assets/protoots-firefox.zip"
+          source-path: "assets/ProToots-${{ github.ref }}.zip"
+          approval-note: |
+            The source code requires Node.js 18 or newer. To generate the source code, run:
+
+            npm ci
+            npm run package
+
+            To check it's functionality, you can enable it on any Mastodon page, such as: https://mastodon.social/public
+          license: OSL-3.0
+          auth-api-issuer: ${{ secrets.FIREFOX_AUTH_API_ISSUER }}
+          auth-api-secret: ${{ secrets.FIREFOX_AUTH_API_SECRET }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "protoots",
 	"scripts": {
 		"build:scripts": "node scripts/build.mjs",
-		"build:webext": "web-ext build --overwrite-dest",
+		"build:webext": "web-ext build --overwrite-dest --filename protoots-firefox.zip",
 		"start": "run-p -l -r watch:**",
 		"watch:scripts": "node scripts/watch.mjs",
 		"watch:webext": "web-ext run --keep-profile-changes --profile-create-if-missing --firefox-profile=.firefox-profile/",


### PR DESCRIPTION
Closes #5

Nicht sicher, ob wir die Firefox-Releases auch signieren sollen, bevor wir sie auf GitHub werfen. Macht an sich ja nicht viel Sinn, wenn das direkt in den Stores veröffentlicht wird.
