### PR TITLE
Adjust matching regex to catch fewer unrelated words

### DIFF
--- a/src/libs/pronouns.js
+++ b/src/libs/pronouns.js
@@ -1,6 +1,6 @@
 import sanitizeHtml from "sanitize-html";
 
-const fieldMatchers = [/pro.*nouns?/i, "pronomen"];
+const fieldMatchers = [/\bpro.*nouns?\b/i, "pronomen"];
 const knownPronounUrls = [
 	/pronouns\.page\/:?([\w/@]+)/,
 	/pronouns\.within\.lgbt\/([\w/]+)/,

--- a/tests/extractPronouns.spec.js
+++ b/tests/extractPronouns.spec.js
@@ -11,6 +11,7 @@ const validFields = [
 	"pronomen",
 	"Pronouns / Pronomen",
 ];
+const invalidFields = ["pronounciation"];
 
 for (const field of validFields) {
 	extract(`${field} is extracted`, async () => {
@@ -20,6 +21,17 @@ for (const field of validFields) {
 			},
 		});
 		assert.equal("pro/nouns", result);
+	});
+}
+
+for (const field of invalidFields) {
+	extract(`${field} is not extracted`, async () => {
+		const result = await pronouns.extractFromStatus({
+			account: {
+				fields: [{ name: field, value: "pro/nouns" }],
+			},
+		});
+		assert.equal(result, null);
 	});
 }
 


### PR DESCRIPTION
The current matching regex can also match words like `pronounciation`, or any other word that starts with `pronoun`. This is an attempt to make the regex more specific. 
In the future it might be better to handle this differently to catch pronouns in other languages (french, ...) besides german/english.
uwu