### PR TITLE
Invalidate old cache versions

### DIFF
--- a/src/libs/caching.js
+++ b/src/libs/caching.js
@@ -1,5 +1,7 @@
 import { debug, error } from "./logging";
-import { storage } from "webextension-polyfill";
+import Browser, { storage } from "webextension-polyfill";
+
+const currentVersion = Browser.runtime.getManifest().version;
 /**
  * Appends an entry to the "pronounsCache" object in local storage.
  *
@@ -15,7 +17,12 @@ export async function cachePronouns(account, pronouns) {
 		cache = { pronounsCache: {} };
 	}
 
-	cache.pronounsCache[account] = { acct: account, timestamp: Date.now(), value: pronouns };
+	cache.pronounsCache[account] = {
+		acct: account,
+		timestamp: Date.now(),
+		value: pronouns,
+		version: currentVersion,
+	};
 	try {
 		await storage.local.set(cache);
 		debug(`${account} cached`);

--- a/src/libs/caching.js
+++ b/src/libs/caching.js
@@ -1,7 +1,9 @@
-import { debug, error } from "./logging";
-import Browser, { storage } from "webextension-polyfill";
+import { debug, info, error } from "./logging.js";
+import { runtime, storage } from "webextension-polyfill";
 
-const currentVersion = Browser.runtime.getManifest().version;
+const currentVersion = runtime.getManifest().version;
+const cacheMaxAge = 24 * 60 * 60 * 1000; // time after which cached pronouns should be checked again: 24h
+
 /**
  * Appends an entry to the "pronounsCache" object in local storage.
  *
@@ -31,7 +33,12 @@ export async function cachePronouns(account, pronouns) {
 	}
 }
 
-export async function getPronouns() {
+/**
+ *
+ * @param {string} accountName
+ * @returns {Promise<string>} Account's cached pronouns, or null if not saved or stale
+ */
+export async function getPronouns(accountName) {
 	const fallback = { pronounsCache: {} };
 	let cacheResult;
 	try {
@@ -45,5 +52,21 @@ export async function getPronouns() {
 		cacheResult = fallback;
 		// ignore errors, we have an empty object as fallback.
 	}
-	return cacheResult;
+
+	// Extract the current cache by using object destructuring.
+	if (accountName in cacheResult.pronounsCache) {
+		const { value, timestamp, version } = cacheResult.pronounsCache[accountName];
+
+		// If we have a cached value and it's not outdated, use it.
+		if (value && Date.now() - timestamp < cacheMaxAge && version == currentVersion) {
+			info(`${accountName} in cache with value: ${value}`);
+			return value;
+		} else {
+			info(`${accountName} cache entry is stale, refreshing`);
+		}
+	} else {
+		info(`${accountName} not in cache, fetching status`);
+	}
+
+	return null;
 }

--- a/src/libs/fetchPronouns.js
+++ b/src/libs/fetchPronouns.js
@@ -2,11 +2,8 @@ import { debug, error, info, log, warn } from "./logging";
 import { cachePronouns, getPronouns } from "./caching";
 import { normaliseAccountName } from "./protootshelpers";
 import { extractFromStatus } from "./pronouns";
-import Browser from "webextension-polyfill";
 
-const cacheMaxAge = 24 * 60 * 60 * 1000; // time after which cached pronouns should be checked again: 24h
 let conversationsCache;
-const currentVersion = Browser.runtime.getManifest().version;
 
 /**
  * Fetches pronouns associated with account name.
@@ -19,22 +16,9 @@ const currentVersion = Browser.runtime.getManifest().version;
  */
 export async function fetchPronouns(dataID, accountName, type) {
 	// log(`searching for ${account_name}`);
-	const cacheResult = await getPronouns();
+	const cacheResult = await getPronouns(accountName);
 	debug(cacheResult);
-	// Extract the current cache by using object destructuring.
-	if (accountName in cacheResult.pronounsCache) {
-		const { value, timestamp, version } = cacheResult.pronounsCache[accountName];
-
-		// If we have a cached value and it's not outdated, use it.
-		if (value && Date.now() - timestamp < cacheMaxAge && version == currentVersion) {
-			info(`${accountName} in cache with value: ${value}`);
-			return value;
-		} else {
-			info(`${accountName} cache entry is stale, refreshing`);
-		}
-	} else {
-		info(`${accountName} not in cache, fetching status`);
-	}
+	if (cacheResult) return cacheResult;
 
 	if (!dataID) {
 		warn(`Could not fetch pronouns for user ${accountName}, because no status ID was passed.`);

--- a/src/libs/fetchPronouns.js
+++ b/src/libs/fetchPronouns.js
@@ -32,16 +32,14 @@ export async function fetchPronouns(dataID, accountName, type) {
 		} else {
 			info(`${accountName} cache entry is stale, refreshing`);
 		}
+	} else {
+		info(`${accountName} not in cache, fetching status`);
 	}
-
-	info(`${accountName} cache entry is stale, refreshing`);
 
 	if (!dataID) {
 		warn(`Could not fetch pronouns for user ${accountName}, because no status ID was passed.`);
 		return null;
 	}
-
-	info(`${accountName} not in cache, fetching status`);
 
 	let status;
 	if (type === "notification") {

--- a/src/libs/fetchPronouns.js
+++ b/src/libs/fetchPronouns.js
@@ -2,9 +2,11 @@ import { debug, error, info, log, warn } from "./logging";
 import { cachePronouns, getPronouns } from "./caching";
 import { normaliseAccountName } from "./protootshelpers";
 import { extractFromStatus } from "./pronouns";
+import Browser from "webextension-polyfill";
 
 const cacheMaxAge = 24 * 60 * 60 * 1000; // time after which cached pronouns should be checked again: 24h
 let conversationsCache;
+const currentVersion = Browser.runtime.getManifest().version;
 
 /**
  * Fetches pronouns associated with account name.
@@ -21,10 +23,10 @@ export async function fetchPronouns(dataID, accountName, type) {
 	debug(cacheResult);
 	// Extract the current cache by using object destructuring.
 	if (accountName in cacheResult.pronounsCache) {
-		const { value, timestamp } = cacheResult.pronounsCache[accountName];
+		const { value, timestamp, version } = cacheResult.pronounsCache[accountName];
 
 		// If we have a cached value and it's not outdated, use it.
-		if (value && Date.now() - timestamp < cacheMaxAge) {
+		if (value && Date.now() - timestamp < cacheMaxAge && version == currentVersion) {
 			info(`${accountName} in cache with value: ${value}`);
 			return value;
 		} else {


### PR DESCRIPTION
Currently, whenever we publish a new version old cache entries stay around, potentially breaking things.
To mitigate this issue, check with which version a cache entry was created and refresh if it's not the same.