### PR TITLE
Don't add a proplate if no nametag is found

### DIFF
--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -331,7 +331,8 @@ async function addProplate(element) {
 		let accountName = getAccountName(accountNameEl, "title");
 		if (!accountName) accountName = accountNameFromURL(getAccountName(accountNameEl, "href"));
 
-		let nametagEl = accountNameEl;
+		let nametagEl = getNametagEl(element, ".notification__display-name");
+		if (!nametagEl) return;
 
 		element.setAttribute("protoots-checked", "true");
 		generateProPlate(statusId, accountName, nametagEl, "notification");


### PR DESCRIPTION
This assures no proplate is added to notification titles, that contain no username (e.g. "A poll you voted in has closed")