### PR TITLE
Fix type error in Mastodon v4.3+

### DIFF
--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -152,10 +152,6 @@ function addtoTootObserver(ActionElement, tootObserver) {
 	// console.log(ActionElement);
 	if (ActionElement.hasAttribute("protoots-tracked")) return;
 
-	// special case for Mastodon v4.3 where "status__wrapper" are created
-	// as "status focusable" after navigating back to timeline
-	if (hasClasses(ActionElement, "status") && hasClasses(ActionElement, "focusable")) return;
-
 	addTypeAttribute(ActionElement);
 	ActionElement.setAttribute("protoots-tracked", "true");
 	tootObserver.observe(ActionElement);

--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -89,7 +89,10 @@ function main() {
 					hasClasses(
 						n,
 						"detailed-status",
-						"status",
+						"status-public",
+						"status-unlisted",
+						"status-private",
+						"status-direct",
 						"conversation",
 						"account-authorize",
 						"notification",

--- a/src/content_scripts/protoots.js
+++ b/src/content_scripts/protoots.js
@@ -149,6 +149,10 @@ function addtoTootObserver(ActionElement, tootObserver) {
 	// console.log(ActionElement);
 	if (ActionElement.hasAttribute("protoots-tracked")) return;
 
+	// special case for Mastodon v4.3 where "status__wrapper" are created
+	// as "status focusable" after navigating back to timeline
+	if (hasClasses(ActionElement, "status") && hasClasses(ActionElement, "focusable")) return;
+
 	addTypeAttribute(ActionElement);
 	ActionElement.setAttribute("protoots-tracked", "true");
 	tootObserver.observe(ActionElement);

--- a/src/libs/protootshelpers.js
+++ b/src/libs/protootshelpers.js
@@ -51,7 +51,10 @@ export function addTypeAttribute(ActionElement) {
 	} else if (hasClasses(ActionElement, "notification", "notification__message")) {
 		ActionElement.setAttribute("protoots-type", "notification");
 		ActionElement.closest("article").setAttribute("protoots-type", "notification");
-	} else if (hasClasses(ActionElement, "account")) {
+	} else if (
+		hasClasses(ActionElement, "account") &&
+		!hasClasses(ActionElement, "account--minimal")
+	) {
 		ActionElement.setAttribute("protoots-type", "account");
 		ActionElement.closest("article").setAttribute("protoots-type", "account");
 	}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "ProToots",
-	"version": "1.2.2",
+	"version": "1.2.3",
 
 	"icons": {
 		"48": "icons/icon small_size/icon small_size.png",


### PR DESCRIPTION
Ensures divs with class "account" don't also have "account--minimal", which is used on the element showing the currently logged-in user. Closes #77.

Also works around a quirk in newer Mastodon versions, which leads to doubled ProPlates when navigating away from the timeline and then back.